### PR TITLE
chore: release 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-vue-collections",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-vue-collections",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud-vue-collections",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Nextcloud vue components for collections",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## What's Changed
* chore: use vue 2.7 reactive function by @DorraJaouad in https://github.com/nextcloud-libraries/nextcloud-vue-collections/pull/1202
* chore: install nextcloud/l10n, use imported translate functions by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue-collections/pull/1227
* chore: Add SPDX headers and REUSE CI workflow by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue-collections/pull/1228
* chore: bump dependencies

## New Contributors
* @Antreesy made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue-collections/pull/1227

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-vue-collections/compare/v0.12.0...v0.13.0

-----

### Release plan:
- [x] get approve on this PR `v0.13.0`
- [ ] merge PR
- [ ] branch-off `master` to `stable0`
- [ ] release `v0.13.0` from `stable0` branch
- [ ] merge vue3 PR to `master`
- [ ] release `v1.0.0`, add comment to README.md about versions compatibility