### PR TITLE
chore: release 1.0.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.0-alpha - 2024-06-17
+### Breaking changes
+The package now uses Vue 3 instead of Vue 2.7. For older versions of Vue please use `0.x` released version
+
+### Changed
+* migrate package to Vue 3
+* chore: Add NPM publish workflow
+
 ## 0.13.0 - 2024-06-16
 ### Changed
 * chore: use vue 2.7 reactive function

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ npm install --save nextcloud-vue-collections
 
 This library requires your app to have the following dependencies installed:
 
-- vue 2.7.16
+- `^1.0.0` or any compatible newer version: `vue ^3.4.29`
+- `^0.12.0` or any compatible newer minor or patch version: `vue ^2.7.16`
 
 After that you can use the collection list component like this:
 


### PR DESCRIPTION
## 1.0.0-alpha - 2024-06-17
### Breaking changes
The package now uses Vue 3 instead of Vue 2.7. For older versions of Vue please use `0.x` released version

### Changed
* migrate package to Vue 3
* chore: Add NPM publish workflow

README.md:
```md
This library requires your app to have the following dependencies installed:

- `^1.0.0` or any compatible newer version: `vue ^3.4.29`
- `^0.12.0` or any compatible newer minor or patch version: `vue ^2.7.16`
```